### PR TITLE
feat: implement shared visits counter across multiple pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Layout from './components/layout/Layout';
 import HomePage from './components/pages/home-page/HomePage';
@@ -8,15 +9,17 @@ import Registration from './components/pages/registration/Registration';
 import './App.css';
 
 function App() {
+  const [visits, setVisits] = useState(0);
+
   return (
     <BrowserRouter>
       <Routes>
         <Route element={<Layout />}>
-          <Route path="/" element={<HomePage />} />
-          <Route path="/browse" element={<SearchBrowse />} />
-          <Route path="/game/:id" element={<GameDetails />} />
-          <Route path="/profile" element={<UserProfile />} />
-          <Route path="/registration" element={<Registration />} />
+          <Route path="/" element={<HomePage visits={visits} setVisits={setVisits} />} />
+          <Route path="/browse" element={<SearchBrowse visits={visits} setVisits={setVisits} />} />
+          <Route path="/game/:id" element={<GameDetails visits={visits} setVisits={setVisits} />} />
+          <Route path="/profile" element={<UserProfile visits={visits} setVisits={setVisits} />} />
+          <Route path="/registration" element={<Registration visits={visits} setVisits={setVisits} />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/components/pages/game-details/GameDetails.tsx
+++ b/src/components/pages/game-details/GameDetails.tsx
@@ -1,8 +1,25 @@
-function GameDetails() {
+import type { Dispatch, SetStateAction } from 'react';
+
+type GameDetailsProps = {
+  visits: number;
+  setVisits: Dispatch<SetStateAction<number>>;
+};
+
+function GameDetails({ visits, setVisits }: GameDetailsProps) {
   return (
     <div className="space-y-6 text-center">
       <h1 className="text-3xl font-bold text-white">Game Details</h1>
       <p className="text-neutral-400">Game details page coming soon...</p>
+      <div className="space-y-2">
+        <p className="text-neutral-400">Shared visits counter: {visits}</p>
+        <button
+          type="button"
+          className="px-4 py-2 bg-neutral-50 text-neutral-950 rounded-md font-medium hover:bg-neutral-200"
+          onClick={() => setVisits((current) => current + 1)}
+        >
+          Add visit
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/pages/home-page/HomePage.tsx
+++ b/src/components/pages/home-page/HomePage.tsx
@@ -1,8 +1,25 @@
-function HomePage() {
+import type { Dispatch, SetStateAction } from 'react';
+
+type HomePageProps = {
+  visits: number;
+  setVisits: Dispatch<SetStateAction<number>>;
+};
+
+function HomePage({ visits, setVisits }: HomePageProps) {
   return (
     <div className="space-y-6 text-center">
       <h1 className="text-3xl font-bold text-white">Welcome to Video Game Tracker</h1>
       <p className="text-neutral-400">Home page content coming soon...</p>
+      <div className="space-y-2">
+        <p className="text-neutral-400">Shared visits counter: {visits}</p>
+        <button
+          type="button"
+          className="px-4 py-2 bg-neutral-50 text-neutral-950 rounded-md font-medium hover:bg-neutral-200"
+          onClick={() => setVisits((current) => current + 1)}
+        >
+          Add visit
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/pages/registration/Registration.tsx
+++ b/src/components/pages/registration/Registration.tsx
@@ -1,8 +1,25 @@
-function Registration() {
+import type { Dispatch, SetStateAction } from 'react';
+
+type RegistrationProps = {
+  visits: number;
+  setVisits: Dispatch<SetStateAction<number>>;
+};
+
+function Registration({ visits, setVisits }: RegistrationProps) {
   return (
     <div className="space-y-6 text-center">
       <h1 className="text-3xl font-bold text-white">Registration</h1>
       <p className="text-neutral-400">Registration page coming soon...</p>
+      <div className="space-y-2">
+        <p className="text-neutral-400">Shared visits counter: {visits}</p>
+        <button
+          type="button"
+          className="px-4 py-2 bg-neutral-50 text-neutral-950 rounded-md font-medium hover:bg-neutral-200"
+          onClick={() => setVisits((current) => current + 1)}
+        >
+          Add visit
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/pages/search-browse/SearchBrowse.tsx
+++ b/src/components/pages/search-browse/SearchBrowse.tsx
@@ -1,8 +1,25 @@
-function SearchBrowse() {
+import type { Dispatch, SetStateAction } from 'react';
+
+type SearchBrowseProps = {
+  visits: number;
+  setVisits: Dispatch<SetStateAction<number>>;
+};
+
+function SearchBrowse({ visits, setVisits }: SearchBrowseProps) {
   return (
     <div className="space-y-6 text-center">
       <h1 className="text-3xl font-bold text-white">Search & Browse Games</h1>
       <p className="text-neutral-400">Search and browse functionality coming soon...</p>
+      <div className="space-y-2">
+        <p className="text-neutral-400">Shared visits counter: {visits}</p>
+        <button
+          type="button"
+          className="px-4 py-2 bg-neutral-50 text-neutral-950 rounded-md font-medium hover:bg-neutral-200"
+          onClick={() => setVisits((current) => current + 1)}
+        >
+          Add visit
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/pages/user-profile/UserProfile.tsx
+++ b/src/components/pages/user-profile/UserProfile.tsx
@@ -1,8 +1,24 @@
+import type { Dispatch, SetStateAction } from 'react';
 import userAvatar from '../../../assets/user.png';
 
-function UserProfile() {
+type UserProfileProps = {
+  visits: number;
+  setVisits: Dispatch<SetStateAction<number>>;
+};
+
+function UserProfile({ visits, setVisits }: UserProfileProps) {
   return (
     <section className="space-y-8">
+      <div className="bg-neutral-900 rounded-lg p-6 border border-neutral-800 text-center space-y-2">
+        <p className="text-neutral-400">Shared visits counter: {visits}</p>
+        <button
+          type="button"
+          className="px-4 py-2 bg-neutral-50 text-neutral-950 rounded-md font-medium hover:bg-neutral-200"
+          onClick={() => setVisits((current) => current + 1)}
+        >
+          Add visit
+        </button>
+      </div>
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 py-8">
         <div className="bg-neutral-900 rounded-lg p-6 border border-neutral-800 lg:col-span-1">
           <div className="flex items-center justify-center w-full h-full">


### PR DESCRIPTION
Adds a shared “visits” counter at the app level and shows it on every page, with a button to increment it. This proves shared state is preserved across routes per Sprint 2 requirement T.3: Shared state across pages (P0).