### PR TITLE
feat: implement user profile management architecture with repository,…

### DIFF
--- a/docs/architecture-mamuse.md
+++ b/docs/architecture-mamuse.md
@@ -1,0 +1,124 @@
+# Architecture – M.A.Muse
+
+This document describes the new components, hooks, services, and repositories added to support user profile management and demonstrate proper architectural separation of concerns.
+
+## UserProfile Type & Test Data
+
+**What does it do?**
+
+The `UserProfile` interface defines the structure of a user account in the system, including username, email, tagline, favorite genres, and creation date. 
+The test data file (`src/data/user_profiles.ts`) provides an array of 11 sample user profiles that the application uses instead of fetching from an external API.
+
+**Why logic here / Separation of concerns:**
+
+By defining the type and test data in a dedicated file, we separate data structure (what a user looks like) from data access (how we retrieve users). 
+This makes it easy to swap test data for real database queries later without changing the rest of the application. 
+Other contributors can keep their own data structures separate in their own files.
+
+**Where is it used?**
+
+Referenced by `userProfileRepository` to provide the dataset, and by `profileService` and `useUserProfiles` through TypeScript imports for type safety. 
+The test data will be replaced with database queries in the next module.
+
+---
+
+## UserProfileRepository
+
+**What does it do?**
+
+The repository provides CRUD methods (`create`, `read`, `update`, `delete`) for user profiles. 
+It's the only layer that knows about or interacts with the data source (currently test data, but could be an API, database, etc.). 
+All other parts of the application must go through this repository to access user data.
+
+**Why logic here / Separation of concerns:**
+
+The repository abstracts away *how* data is stored or retrieved. 
+If we later switch from test data to a REST API or a database, we only change the repository—components, hooks, and services don't need to know or care. 
+This is the principle of *Dependency Inversion*: business logic depends on abstractions (the repository interface), not concrete implementations.
+
+**Where is it used?**
+
+Called by `profileService` to perform all data operations. 
+Never called directly by components; the service layer sits in between to allow for business rule validation and transformation.
+
+---
+
+## ProfileService
+
+**What does it do?**
+
+The service wraps repository calls and provides a place for business logic. 
+For example, you might add email validation, password hashing, audit logging, or permission checks here before persisting data. 
+Currently it passes calls through to the repository, but it's ready for future business rules.
+
+**Why logic here / Separation of concerns:**
+
+Separates *business logic* from *data access* and *UI presentation*. 
+Components don't need to know about validation rules or side effects—they just call the service. 
+If business rules change, we update the service, not every component that uses profiles. 
+This keeps concerns distinct: services handle "what should happen," repositories handle "where data lives."
+
+**Where is it used?**
+
+Called by the `useUserProfiles` hook, which calls methods like `profileService.create()`, `profileService.getAll()`, etc. 
+Components never call the service directly; they use the hook to stay decoupled from service details.
+
+---
+
+## useUserProfiles Hook
+
+**What does it do?**
+
+A custom React hook that manages user profile state at the component level. 
+It fetches all profiles on mount, provides a `createProfile` method to add new profiles, and handles loading state. 
+When a component uses this hook, it gets reactivity and proper state management without needing to orchestrate service calls itself.
+
+**Why logic here / Separation of concerns:**
+
+React components should focus on rendering UI, not orchestrating data fetches or state updates. 
+By extracting that logic into a hook, we keep components clean and reusable. 
+The hook sits between the React component layer and the service/repository layers, translating async data operations into React state.
+
+**Where is it used?**
+
+Used by the `Registration` component in `src/components/pages/registration/Registration.tsx`. 
+When the user submits the registration form, the component calls `createProfile()` (from the hook), 
+which calls `profileService.create()`, which calls `userProfileRepository.create()`, which stores the data. 
+This is the demonstration of the full architecture stack.
+
+---
+
+## Registration Component Integration
+
+**What does it do?**
+
+The Registration page is now the working example that ties all pieces together. 
+When a user fills out the form and clicks "Create account," it invokes the hook, which invokes the service, which invokes the repository. 
+This demonstrates that the new architecture works end-to-end.
+
+**Why logic here / How it fits the architecture:**
+
+The Registration component has inline comments explaining:
+- That it uses the `useUserProfiles` hook for state and data operations
+- That the hook calls `profileService`
+- That the service calls `userProfileRepository`
+- That the repository accesses test data
+- Why each layer exists and what concerns it handles
+This makes it clear to future contributors how the architecture is structured and where to add new logic when needed.
+
+**Where is it used in the project:**
+
+Located at `src/components/pages/registration/Registration.tsx`. It's part of the main application's page navigation and is the user-facing demonstration of the new architecture.
+
+
+## Summary
+
+The architecture creates a clean separation:
+
+1. **Data Layer** (`user_profiles.ts`): Defines what user data looks like  
+2. **Repository Layer** (`userProfileRepository`): Handles how to access/store user data  
+3. **Service Layer** (`profileService`): Applies business rules to user operations  
+4. **Hook Layer** (`useUserProfiles`): Provides React state management and reactivity  
+5. **Component Layer** (`Registration`): Renders UI and delegates to the hook  
+
+When the backend is ready, only the repository needs to change. Everything else—services, hooks, components—keeps working.

--- a/src/components/pages/registration/Registration.tsx
+++ b/src/components/pages/registration/Registration.tsx
@@ -8,6 +8,7 @@ import {
   removeGenre,
   isFormValid,
 } from '../../../services/registrationService';
+import { useUserProfiles } from '../../../hooks/useUserProfiles/useUserProfiles';
 
 type RegistrationProps = {
   visits: number;
@@ -104,6 +105,19 @@ function RegistrationForm({ formState, setFormState, errors }: RegistrationFormP
  * with a display name, email, tagline, and favorite genres. Also includes
  * a shared visits counter.
  * 
+ * ARCHITECTURE: This component demonstrates the full stack:
+ * 1. It invokes the `useUserProfiles` custom hook (which manages state)
+ * 2. The hook calls `profileService.create()` (which handles business logic)
+ * 3. The service calls `userProfileRepository.create()` (which accesses/persists data)
+ * 4. The repository uses test data from `user_profiles.ts` (which will be a database later)
+ * 
+ * Concerns are properly separated:
+ * - COMPONENT: handles UI rendering and user input
+ * - HOOK: manages loading state and data synchronization
+ * - SERVICE: applies business rules (validation, transformations)
+ * - REPOSITORY: abstracts data access (test data now, API later)
+ * - DATA: defines the shape of user profiles
+ * 
  * @param visits - The current number of visits.
  * @param setVisits - Function to update the number of visits.
  * 
@@ -111,6 +125,9 @@ function RegistrationForm({ formState, setFormState, errors }: RegistrationFormP
  */
 
 function Registration({ visits, setVisits }: RegistrationProps) {
+  // Hook provides createProfile method and loading state for the architecture chain
+  const { createProfile } = useUserProfiles();
+
   const [formState, setFormState] = useState<RegistrationFormState>({
     displayName: '',
     email: '',
@@ -118,6 +135,7 @@ function Registration({ visits, setVisits }: RegistrationProps) {
   });
   const [newGenre, setNewGenre] = useState('');
   const [favoriteGenres, setFavoriteGenres] = useState<string[]>(['Action', 'RPG']);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const displayNameError = getDisplayNameError(formState.displayName);
   const emailError = getEmailError(formState.email);
@@ -132,6 +150,33 @@ function Registration({ visits, setVisits }: RegistrationProps) {
 
   const handleRemoveGenre = (genreToRemove: string) => {
     setFavoriteGenres((current) => removeGenre(current, genreToRemove));
+  };
+
+  /**
+   * Handles account creation by calling the useUserProfiles hook's createProfile method.
+   * This kicks off the chain: hook → service → repository → storage
+   */
+  const handleCreateAccount = async () => {
+    setIsSubmitting(true);
+    try {
+      await createProfile({
+        username: formState.displayName.trim(),
+        email: formState.email.trim(),
+        tagline: formState.tagline.trim(),
+        favoriteGenres,
+        createdAt: new Date().toISOString().split('T')[0], // YYYY-MM-DD format
+      });
+      // Success! In a real app, you'd navigate or show a success message
+      alert('Profile created successfully!');
+      // Reset the form
+      setFormState({ displayName: '', email: '', tagline: '' });
+      setFavoriteGenres(['Action', 'RPG']);
+    } catch (error) {
+      console.error('Error creating profile:', error);
+      alert('Failed to create profile. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
@@ -274,10 +319,11 @@ function Registration({ visits, setVisits }: RegistrationProps) {
 
           <button
             type="button"
-            disabled={!isFormValid(formState.displayName, formState.email)}
+            onClick={handleCreateAccount}
+            disabled={!isFormValid(formState.displayName, formState.email) || isSubmitting}
             className="w-full px-4 py-2 bg-neutral-50 text-neutral-950 rounded-md font-medium hover:bg-neutral-200 disabled:cursor-not-allowed disabled:bg-neutral-700 disabled:text-neutral-300"
           >
-            Create account
+            {isSubmitting ? 'Creating account...' : 'Create account'}
           </button>
         </div>
       </div>

--- a/src/data/user_profiles.ts
+++ b/src/data/user_profiles.ts
@@ -1,0 +1,108 @@
+/**
+ * Defines the structure of a user profile within the application.
+ * A user profile represents a player's account and preferences.
+ */
+export interface UserProfile {
+  id: number;
+  username: string;
+  email: string;
+  tagline: string;
+  favoriteGenres: string[];
+  createdAt: string;
+}
+
+/**
+ * Test data: array of 10+ sample user profiles.
+ * This data is used by the userProfileRepository instead of making external API calls.
+ * In a future sprint, this will be replaced with database queries.
+ */
+export const userProfiles: UserProfile[] = [
+  {
+    id: 1,
+    username: 'PixelRanger',
+    email: 'pixel@example.com',
+    tagline: 'Co-op first, speedruns second.',
+    favoriteGenres: ['Action', 'RPG'],
+    createdAt: '2025-11-15',
+  },
+  {
+    id: 2,
+    username: 'SilentHunter',
+    email: 'silent@example.com',
+    tagline: 'Stealth games are life.',
+    favoriteGenres: ['Stealth', 'Thriller'],
+    createdAt: '2025-10-20',
+  },
+  {
+    id: 3,
+    username: 'CasualGamer',
+    email: 'casual@example.com',
+    tagline: 'Here for the vibes.',
+    favoriteGenres: ['Puzzle', 'Adventure'],
+    createdAt: '2025-09-05',
+  },
+  {
+    id: 4,
+    username: 'CompetitivePro',
+    email: 'competitive@example.com',
+    tagline: 'Rank 1 or bust.',
+    favoriteGenres: ['Fighting', 'Shooter'],
+    createdAt: '2025-08-12',
+  },
+  {
+    id: 5,
+    username: 'StoryDiver',
+    email: 'story@example.com',
+    tagline: 'Plot twists > graphics.',
+    favoriteGenres: ['RPG', 'Adventure'],
+    createdAt: '2025-07-30',
+  },
+  {
+    id: 6,
+    username: 'NoLifeGamer',
+    email: 'nolife@example.com',
+    tagline: 'What is sleep?',
+    favoriteGenres: ['Strategy', 'Simulation'],
+    createdAt: '2025-06-18',
+  },
+  {
+    id: 7,
+    username: 'RetroFan',
+    email: 'retro@example.com',
+    tagline: 'Pixel art > ultra-realistic.',
+    favoriteGenres: ['Platformer', 'Arcade'],
+    createdAt: '2025-05-22',
+  },
+  {
+    id: 8,
+    username: 'CasualStreamer',
+    email: 'streamer@example.com',
+    tagline: 'Making games look easy since 2024.',
+    favoriteGenres: ['Action', 'Racing'],
+    createdAt: '2025-04-10',
+  },
+  {
+    id: 9,
+    username: 'PuzzleMaster',
+    email: 'puzzle@example.com',
+    tagline: 'Brain > brawn.',
+    favoriteGenres: ['Puzzle', 'Turn-based'],
+    createdAt: '2025-03-05',
+  },
+  {
+    id: 10,
+    username: 'SoulsLikeEnthusiast',
+    email: 'soulslike@example.com',
+    tagline: 'Pain is temporary, victory is forever.',
+    favoriteGenres: ['RPG', 'Action'],
+    createdAt: '2025-02-14',
+  },
+  {
+    id: 11,
+    username: 'IndieGameLover',
+    email: 'indie@example.com',
+    tagline: 'Supporting small devs with big dreams.',
+    favoriteGenres: ['Adventure', 'Indie'],
+    createdAt: '2025-01-28',
+  },
+];

--- a/src/hooks/useUserProfiles/useUserProfiles.ts
+++ b/src/hooks/useUserProfiles/useUserProfiles.ts
@@ -1,0 +1,91 @@
+import { useState, useEffect } from 'react';
+import { profileService } from '../../services/profileService';
+import type { UserProfile } from '../../data/user_profiles';
+
+/**
+ * Custom hook to manage user profiles in a component.
+ * Fetches all profiles on mount via the profileService, which calls the repository.
+ * Provides loading state and the list of profiles for the component to render.
+ *
+ * @returns An object with the profiles array and a loading flag.
+ */
+export function useUserProfiles() {
+  const [profiles, setProfiles] = useState<UserProfile[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // Fetch all profiles when the hook is first used
+  useEffect(() => {
+    const loadProfiles = async () => {
+      try {
+        const data = await profileService.getAll();
+        setProfiles(data);
+      } catch (error) {
+        console.error('Failed to load user profiles:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadProfiles();
+  }, []);
+
+  /**
+   * Creates a new user profile by calling the profileService.
+   * This is what the Registration component calls when the user submits the form.
+   */
+  const createProfile = async (profileData: Omit<UserProfile, 'id'>) => {
+    try {
+      const newProfile = await profileService.create(profileData);
+      // Update the local list to include the newly created profile
+      setProfiles(prev => [...prev, newProfile]);
+      return newProfile;
+    } catch (error) {
+      console.error('Failed to create user profile:', error);
+      throw error;
+    }
+  };
+
+  /**
+   * Updates an existing user profile by calling the profileService.
+   */
+  const updateProfile = async (id: number, updates: Partial<Omit<UserProfile, 'id'>>) => {
+    try {
+      const updated = await profileService.update(id, updates);
+      if (updated) {
+        // Update the local list with the modified profile
+        setProfiles(prev =>
+          prev.map(p => (p.id === id ? updated : p))
+        );
+      }
+      return updated;
+    } catch (error) {
+      console.error('Failed to update user profile:', error);
+      throw error;
+    }
+  };
+
+  /**
+   * Deletes a user profile by calling the profileService.
+   */
+  const deleteProfile = async (id: number) => {
+    try {
+      const success = await profileService.delete(id);
+      if (success) {
+        // Remove the deleted profile from the local list
+        setProfiles(prev => prev.filter(p => p.id !== id));
+      }
+      return success;
+    } catch (error) {
+      console.error('Failed to delete user profile:', error);
+      throw error;
+    }
+  };
+
+  return {
+    profiles,
+    loading,
+    createProfile,
+    updateProfile,
+    deleteProfile,
+  };
+}

--- a/src/repositories/userProfileRepository.ts
+++ b/src/repositories/userProfileRepository.ts
@@ -1,0 +1,82 @@
+import { userProfiles, type UserProfile } from '../data/user_profiles';
+
+/**
+ * Repository for accessing UserProfile data.
+ * Abstracts all data access logic so the application doesn't need to know
+ * whether data comes from test files, APIs, or databases.
+ * Currently uses local test data, but can be swapped to external services later.
+ */
+export const userProfileRepository = {
+  /**
+   * Fetches all user profiles.
+   *
+   * @returns A promise resolving to an array of all user profiles.
+   */
+  getAll: async (): Promise<UserProfile[]> => {
+    // Simulate network delay to match real API behavior (100ms)
+    await new Promise(resolve => setTimeout(resolve, 100));
+    return userProfiles;
+  },
+
+  /**
+   * Fetches a single user profile by its ID.
+   *
+   * @param id - The unique identifier of the user profile.
+   * @returns A promise resolving to the user profile, or undefined if not found.
+   */
+  getById: async (id: number): Promise<UserProfile | undefined> => {
+    await new Promise(resolve => setTimeout(resolve, 100));
+    return userProfiles.find(profile => profile.id === id);
+  },
+
+  /**
+   * Creates a new user profile and adds it to the collection.
+   * In a real app, this would send data to a database.
+   *
+   * @param profile - The user profile object to create (without an ID).
+   * @returns A promise resolving to the newly created profile with an assigned ID.
+   */
+  create: async (profile: Omit<UserProfile, 'id'>): Promise<UserProfile> => {
+    await new Promise(resolve => setTimeout(resolve, 100));
+    // Generate a new ID (in production, the database would do this)
+    const newId = Math.max(...userProfiles.map(p => p.id), 0) + 1;
+    const newProfile: UserProfile = { ...profile, id: newId };
+    userProfiles.push(newProfile);
+    return newProfile;
+  },
+
+  /**
+   * Updates an existing user profile by ID.
+   * In a real app, this would persist changes to a database.
+   *
+   * @param id - The unique identifier of the profile to update.
+   * @param updates - The fields to update (partial profile data).
+   * @returns A promise resolving to the updated profile, or undefined if not found.
+   */
+  update: async (
+    id: number,
+    updates: Partial<Omit<UserProfile, 'id'>>
+  ): Promise<UserProfile | undefined> => {
+    await new Promise(resolve => setTimeout(resolve, 100));
+    const profile = userProfiles.find(p => p.id === id);
+    if (!profile) return undefined;
+    // Merge updates into the existing profile
+    Object.assign(profile, updates);
+    return profile;
+  },
+
+  /**
+   * Deletes a user profile by ID.
+   * In a real app, this would remove the record from the database.
+   *
+   * @param id - The unique identifier of the profile to delete.
+   * @returns A promise resolving to true if deleted, false if not found.
+   */
+  delete: async (id: number): Promise<boolean> => {
+    await new Promise(resolve => setTimeout(resolve, 100));
+    const index = userProfiles.findIndex(p => p.id === id);
+    if (index === -1) return false;
+    userProfiles.splice(index, 1);
+    return true;
+  },
+};

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -1,0 +1,69 @@
+import { userProfileRepository } from '../repositories/userProfileRepository';
+import type { UserProfile } from '../data/user_profiles';
+
+/**
+ * Service that handles business logic for user profile operations.
+ * Acts as a middleman between components/hooks and the repository,
+ * allowing for validation, transformation, or other business rules before
+ * data is accessed or stored.
+ */
+export const profileService = {
+  /**
+   * Retrieves all user profiles from the repository.
+   *
+   * @returns A promise resolving to an array of all user profiles.
+   */
+  getAll: async (): Promise<UserProfile[]> => {
+    return userProfileRepository.getAll();
+  },
+
+  /**
+   * Retrieves a single user profile by ID.
+   *
+   * @param id - The unique identifier of the user profile.
+   * @returns A promise resolving to the user profile, or undefined if not found.
+   */
+  getById: async (id: number): Promise<UserProfile | undefined> => {
+    return userProfileRepository.getById(id);
+  },
+
+  /**
+   * Creates a new user profile with the provided data.
+   * This is the service layer that components should call when registering.
+   *
+   * @param profile - The user profile data to create (without ID).
+   * @returns A promise resolving to the newly created profile with an assigned ID.
+   */
+  create: async (profile: Omit<UserProfile, 'id'>): Promise<UserProfile> => {
+    // In the future, you could add business logic here:
+    // - Validate email uniqueness
+    // - Hash passwords
+    // - Send welcome emails
+    // - Create audit logs
+    return userProfileRepository.create(profile);
+  },
+
+  /**
+   * Updates an existing user profile.
+   *
+   * @param id - The unique identifier of the profile to update.
+   * @param updates - The fields to update.
+   * @returns A promise resolving to the updated profile, or undefined if not found.
+   */
+  update: async (
+    id: number,
+    updates: Partial<Omit<UserProfile, 'id'>>
+  ): Promise<UserProfile | undefined> => {
+    return userProfileRepository.update(id, updates);
+  },
+
+  /**
+   * Deletes a user profile by ID.
+   *
+   * @param id - The unique identifier of the profile to delete.
+   * @returns A promise resolving to true if deleted, false if not found.
+   */
+  delete: async (id: number): Promise<boolean> => {
+    return userProfileRepository.delete(id);
+  },
+};


### PR DESCRIPTION
… service, and hook layers 

This branch adds a new UserProfile resource with a full data‑access stack (type, in‑memory test data, repository with CRUD methods, service layer, and a custom hook). The existing registration page is refactored to call the hook/service/repository chain when creating a profile. 

All calls to user data now go through the repository and use the test data array; when a backend arrives only the repository will change. 
**UI currently only shows the “create” operation on the registration page**.  The additional list/edit/delete UI components will be added in future PRs.